### PR TITLE
Add build instructions for the Twitter classifier assembly.

### DIFF
--- a/twitter_classifier/scala/README.md
+++ b/twitter_classifier/scala/README.md
@@ -2,12 +2,10 @@
 
 Steps for building the assembly:
 
-1. If you don't have [SBT](http://www.scala-sbt.org/) installed, follow the instructions on the SBT website.  Later instructions below are for SBT 0.13.
+1. If you don't have [SBT](http://www.scala-sbt.org/) installed, follow the instructions on the SBT website.  The remaining instructions, below, assume you are using SBT 0.13. 
 * Add the [`sbt-assembly`](https://github.com/sbt/sbt-assembly) plugin (SBT 0.13).  To do so globally, follow these steps:
   1. Create a SBT plugin directory.  Example: `$ mkdir -p ~/.sbt/0.13/plugins`
   * Add the published sbt-assembly plugin.  Example: `$ cat 'addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")' > ~/.sbt/0.13/plugins/assembly.sbt`
 * Finally run SBT using the `assembly` target.  Example: `$ sbt clean assembly`
 
 Upon successfully building the assembly, you should be able to run the various Spark jobs as documented in the [Gitbook](https://www.gitbook.io/read/book/databricks/databricks-spark-reference-applications).
-
-* 


### PR DESCRIPTION
It wasn't clear how to build the assembly documented in the book, so I've added a README file to the project source directory.

I was thinking this might be useful to mention in the book itself, but I am not familiar enough with Gitbooks, nor your conventions to do so with any confidence.

Another option I considered would be to add `assembly.sbt` to `.../twitter_classifier/scala/project` and clean this special case up in the ignore settings.  This would allow building the assembly out of the box (assuming one is using the correct version of SBT).
