### PR TITLE
Tweak example examine and train command to actually work.

### DIFF
--- a/twitter_classifier/run_part2.md
+++ b/twitter_classifier/run_part2.md
@@ -14,8 +14,8 @@ Here is an example command to run [ExamineAndTrain.scala](scala/src/main/scala/c
      --class "com.databricks.apps.twitter_classifier.ExamineAndTrain" \
      --master ${YOUR_SPARK_MASTER:-local[4]} \
      target/scala-2.10/spark-twitter-lang-classifier-assembly-1.0.jar \
-     ${YOUR_TWEET_INPUT:-/tmp/tweets/tweets*/part-*} \
-     ${OUTPUT_MODEL_DIR:-/tmp/tweets/model}
+     "${YOUR_TWEET_INPUT:-/tmp/tweets/tweets*/part-*}" \
+     ${OUTPUT_MODEL_DIR:-/tmp/tweets/model} \
      ${NUM_CLUSTERS:-10} \
      ${NUM_ITERATIONS:-20}
 ```


### PR DESCRIPTION
The input argument needs quotes to keep the shell from expanding the wildcards, and a line continuation was missing.
