### PR TITLE
Update Collect.scala

### DIFF
--- a/twitter_classifier/scala/src/main/scala/com/databricks/apps/twitter_classifier/Collect.scala
+++ b/twitter_classifier/scala/src/main/scala/com/databricks/apps/twitter_classifier/Collect.scala
@@ -39,8 +39,7 @@ object Collect {
 
     val tweetStream = TwitterUtils.createStream(ssc, Utils.getAuth)
       .map(gson.toJson(_))
-      .filter(!_.contains("boundingBoxCoordinates")) // TODO(vida): Remove this workaround when SPARK-3390 is fixed.
-
+      
     tweetStream.foreachRDD((rdd, time) => {
       val count = rdd.count()
       if (count > 0) {


### PR DESCRIPTION
Fixes [issue #50: Pending TODO can be completed: SPARK-3390 was fixed] (https://github.com/databricks/reference-apps/issues/50). I've tested it in Spark 1.2.0 and it works, as expected. For Spark 1.1.0, it fails. So when this project moves to Spark 1.2.0, I propose to merge this pull request.